### PR TITLE
goose->goose-ai in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ pipx ensurepath
 Then you can install goose with 
 
 ``` sh
-pipx install goose
+pipx install goose-ai
 ```
 
 ### Config


### PR DESCRIPTION
Per the tin. Goose appears to be publishing as [goose-ai](https://pypi.org/project/goose-ai/) on pypi. Fixes #6 