### PR TITLE
conditionally publish only when config changes

### DIFF
--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -2,12 +2,8 @@ name: PYPI Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
-    paths:
-      - 'pyproject.toml'
 
 jobs:
   pypi_release:

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -6,6 +6,8 @@ on:
       - main
     tags:
       - 'v*'
+    paths:
+      - 'pyproject.toml'
 
 jobs:
   pypi_release:


### PR DESCRIPTION
Hopefully this would fix incorrect breaking of main when things are not published: 

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#using-filters-to-target-specific-branches-for-pull-request-events