### PR TITLE
Enable cli options for plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "goose-ai"
 description = "a programming agent that runs on your machine"
-version = "0.8.0"
+version = "0.8.1"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
@@ -30,8 +30,10 @@ default = "goose.profile:default_profile"
 [project.entry-points."goose.command"]
 file = "goose.command.file:FileCommand"
 
-[project.entry-points."goose.cli"]
+[project.entry-points."goose.cli.group"]
 goose = "goose.cli.main:goose_cli"
+
+[project.entry-points."goose.cli.group_option"]
 
 [project.scripts]
 goose = "goose.cli.main:cli"

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -13,20 +12,9 @@ from goose.cli.session import Session
 from goose.utils import load_plugins
 from goose.utils.session_file import list_sorted_session_files
 
-def add_group_option(group, option):
-    """
-    Adds a given option to the group.
-    
-    :param group: The Click group to which the option will be added.
-    :param option: The Click option to add.
-    """
-    group = option(group)
-    return group
-
 @click.group()
 def goose_cli() -> None:
     pass
-
 
 @goose_cli.command()
 def version() -> None:
@@ -91,7 +79,7 @@ def session_start(profile: str, plan: Optional[str] = None) -> None:
 @session.command(name="resume")
 @click.argument("name", required=False)
 @click.option("--profile")
-def session_resume(name: str, profile: str) -> None:
+def session_resume(name: str|None, profile: str) -> None:
     """Resume an existing goose session"""
     if name is None:
         session_files = get_session_files()
@@ -107,6 +95,7 @@ def session_resume(name: str, profile: str) -> None:
 
 @session.command(name="list")
 def session_list() -> None:
+    """List goose sessions"""
     session_files = get_session_files().items()
     for session_name, session_file in session_files:
         print(f"{datetime.fromtimestamp(session_file.stat().st_mtime).strftime('%Y-%m-%d %H:%M:%S')}    {session_name}")
@@ -115,6 +104,7 @@ def session_list() -> None:
 @session.command(name="clear")
 @click.option("--keep", default=3, help="Keep this many entries, default 3")
 def session_clear(keep: int) -> None:
+    """Delete old goose sessions, keeping the most recent sessions up to the specified number"""
     for i, (_, session_file) in enumerate(get_session_files().items()):
         if i >= keep:
             session_file.unlink()
@@ -123,58 +113,22 @@ def session_clear(keep: int) -> None:
 def get_session_files() -> Dict[str, Path]:
     return list_sorted_session_files(SESSIONS_PATH)
 
-
-def describe_command(cmd: click.Command) -> dict:
-    ret = {
-        "name": cmd.name,
-        "summary": cmd.get_short_help_str().rstrip("."),
-    }
-
-    if isinstance(cmd, click.Group):
-        ret["commands"] = [
-            describe_command(subcmd) for name, subcmd in cmd.commands.items()
-        ]
-
-    return ret
-
-
-def describe_callback(ctx, param, value):
-    if not value or ctx.resilient_parsing:
-        return
-
-    desc = describe_command(ctx.command)
-    desc["name"] = ctx.info_name  # Set the correct name
-    desc["summary"] = ctx.command.get_short_help_str().rstrip(".")  # Set the summary
-    click.echo(json.dumps(desc, sort_keys=True, indent=2))
-    ctx.exit()
-
-
-describe_option = click.option(
-    "--describe-commands",
-    is_flag=True,
-    type=bool,
-    help="List command descriptions for sq integration and exit.",
-    hidden=True,
-    default=False,
-    is_eager=True,
-    callback=describe_callback,
-)
-
-
-@click.group(invoke_without_command=True, name="tea",
-    help="CLI tool to retrieve Temporary Elevated Access (TEA) credentials",)
-# @describe_option
+@click.group(
+        invoke_without_command=False,
+        name="goose",
+        help="AI-powered tool to assist in solving a wide range of programming and operational tasks",)
 @click.pass_context
-def cli(ctx, describe_commands):
+def cli(_: click.Context) -> None:
     pass
 
-cli = add_group_option(cli, describe_option)
-all_clis = load_plugins("goose.cli")
-for group in all_clis.values():
+all_cli_group_options = load_plugins("goose.cli.group_option")
+for option in all_cli_group_options.values():
+    cli = option()(cli)
+
+all_cli_groups = load_plugins("goose.cli.group")
+for group in all_cli_groups.values():
     for command in group.commands.values():
         cli.add_command(command)
 
-
 if __name__ == "__main__":
-    # merge_commands()
     cli()

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -116,7 +116,7 @@ def get_session_files() -> Dict[str, Path]:
 @click.group(
         invoke_without_command=True,
         name="goose",
-        help="AI-powered tool to assist in solving a wide range of programming and operational tasks",)
+        help="AI-powered tool to assist in solving programming and operational tasks",)
 @click.pass_context
 def cli(_: click.Context, **kwargs: Dict) -> None:
     pass

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -79,7 +79,7 @@ def session_start(profile: str, plan: Optional[str] = None) -> None:
 @session.command(name="resume")
 @click.argument("name", required=False)
 @click.option("--profile")
-def session_resume(name: str|None, profile: str) -> None:
+def session_resume(name: Optional[str], profile: str) -> None:
     """Resume an existing goose session"""
     if name is None:
         session_files = get_session_files()

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -114,11 +114,11 @@ def get_session_files() -> Dict[str, Path]:
     return list_sorted_session_files(SESSIONS_PATH)
 
 @click.group(
-        invoke_without_command=False,
+        invoke_without_command=True,
         name="goose",
         help="AI-powered tool to assist in solving a wide range of programming and operational tasks",)
 @click.pass_context
-def cli(_: click.Context) -> None:
+def cli(_: click.Context, **kwargs: Dict) -> None:
     pass
 
 all_cli_group_options = load_plugins("goose.cli.group_option")


### PR DESCRIPTION
**Why**
Added the entry point `goose.cli.group_option`so that the plugin can add customised command option as top level cli 

**What**
- added the entry point `goose.cli.group_option` and load plugins
- rename the entry point `"goose.cli` to `goose.cli.group` 
- update the version (will coordinate with the versions in other PRs)

