### PR TITLE
goose version command fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "goose-ai"
 description = "a programming agent that runs on your machine"
-version = "0.8.1"
+version = "0.8.2"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "attrs>=23.2.0",
     "rich>=13.7.1",
     "ruamel-yaml>=0.18.6",
-    "ai-exchange>=0.8.0",
+    "ai-exchange>=0.8.1",
     "click>=8.1.7",
     "prompt-toolkit>=3.0.47",
 ]
@@ -17,6 +17,9 @@ packages = [{ include = "goose", from = "src" }]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/goose"]
+
+[project.entry-points."metadata.plugins"]
+goose-ai = ""
 
 [project.entry-points."goose.toolkit"]
 developer = "goose.toolkit.developer:Developer"
@@ -47,4 +50,3 @@ dev-dependencies = [
     "pytest>=8.3.2",
     "codecov>=2.1.13",
 ]
-

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -21,28 +21,15 @@ def version() -> None:
     """Lists the version of goose and any plugins"""
     from importlib.metadata import entry_points, version
 
-    print(f"[green]Goose[/green]: [bold][cyan]{version('goose')}[/cyan][/bold]")
+    print(f"[green]Goose-ai[/green]: [bold][cyan]{version('goose-ai')}[/cyan][/bold]")
     print("[green]Plugins[/green]:")
-    filtered_groups = {}
+    entry_points = entry_points(group="metadata.plugins")
     modules = set()
-    if sys.version_info.minor >= 12:
-        for ep in entry_points():
-            group = getattr(ep, "group", None)
-            if group and (group.startswith("exchange.") or group.startswith("goose.")):
-                filtered_groups.setdefault(group, []).append(ep)
-        for eps in filtered_groups.values():
-            for ep in eps:
-                module_name = ep.module.split(".")[0]
-                modules.add(module_name)
-    else:
-        eps = entry_points()
-        for group, entries in eps.items():
-            if group.startswith("exchange.") or group.startswith("goose."):
-                for entry in entries:
-                    module_name = entry.value.split(".")[0]
-                    modules.add(module_name)
 
-    modules.remove("goose")
+    for ep in entry_points:
+        module_name = ep.name
+        modules.add(module_name)
+    modules.remove("goose-ai")
     for module in sorted(list(modules)):
         # TODO: figure out how to get this to work for goose plugins block
         # as the module name is set to block.goose.cli


### PR DESCRIPTION
Solving the issue https://github.com/square/goose/issues/29

- Created an entry point for `goose` (`goose-ai` package)
- Fixed the issue where modules weren’t imported correctly during the `uv run goose version`

Corresponding PR in exchange:
https://github.com/square/exchange/pull/16
