### PR TITLE
Lifei/fix GitHub workflow triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,34 +25,3 @@ jobs:
       run: |
         uv run pytest tests -m 'not integration'
 
-  create_tag:
-    runs-on: ubuntu-latest
-    needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install UV
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-    - name: Source Cargo Environment
-      run: source $HOME/.cargo/env
-
-    - name: Build with UV
-      run: uvx --from build pyproject-build --installer uv
-
-    - name: Check tag exists
-      run: |
-        dist_file_name=$(cd dist && ls goose-ai*.tar.gz)
-        ./scripts/check_tag_exists.sh $dist_file_name
-      env:
-        GITHUB_ENV: $GITHUB_ENV
-
-    - name: Create tag if it doesn't exist
-      if: env.tag_version != ''
-      run: |
-        git tag "v$tag_version"
-        git push origin "v$tag_version"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: 
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,35 @@ jobs:
     - name: Run tests
       run: |
         uv run pytest tests -m 'not integration'
+
+  create_tag:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install UV
+      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    - name: Source Cargo Environment
+      run: source $HOME/.cargo/env
+
+    - name: Build with UV
+      run: uvx --from build pyproject-build --installer uv
+
+    - name: Check tag exists
+      run: |
+        dist_file_name=$(cd dist && ls goose-ai*.tar.gz)
+        ./scripts/check_tag_exists.sh $dist_file_name
+      env:
+        GITHUB_ENV: $GITHUB_ENV
+
+    - name: Create tag if it doesn't exist
+      if: env.tag_version != ''
+      run: |
+        git tag "v$tag_version"
+        git push origin "v$tag_version"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
       - name: Install UV
         run: curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -1,18 +1,19 @@
 name: PYPI Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   pypi_release:
     runs-on: ubuntu-latest
-
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install UV
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -23,7 +24,23 @@ jobs:
       - name: Build with UV
         run: uvx --from build pyproject-build --installer uv
 
+      - name: Check tag exists
+        run: |
+          dist_file_name=$(cd dist && ls goose-ai*.tar.gz)
+          ./scripts/check_tag_exists.sh $dist_file_name
+        env:
+          GITHUB_ENV: $GITHUB_ENV
+
+      - name: Create tag if it doesn't exist
+        if: env.tag_version != ''
+        run: |
+          git tag "v$tag_version"
+          git push origin "v$tag_version"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish
+        if: ${{ success() }}
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__

--- a/scripts/check_tag_exists.sh
+++ b/scripts/check_tag_exists.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+dist_file_name="$1"
+echo "dist_file_name=$dist_file_name"
+
+version=$(echo "$dist_file_name" | sed -E 's/^goose-ai-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz$/\1/')
+echo "version=$version"
+
+if [ "$version" != "$dist_file_name" ]; then
+    git fetch --tags
+    tag_exists=$(git tag --list "v$version")
+    echo "tag_exists=$tag_exists"
+fi
+if [ -z "$tag_exists" ]; then
+    echo "version $version is not tagged yet"
+    echo "tag_version=$version" >> "$GITHUB_ENV"
+else
+    echo "Tag exists"
+fi


### PR DESCRIPTION
**Why**
Currently we don't have mechanism to create the version tag and publish the package for new version

**What**
- Enabled build on main branch
- Created a script file to check whether the version tag already exists
- Create a version tag when main branch passes the build and no same version tag exists
- When publishing the package, checkout the code with the tag version

**Note**
I heard we are also going to discuss the semantic version for auto version.  Before the decision on the semantic version, we may use this mechanism in the PR, at least we can release new versions