### PR TITLE
adding in ability to provide per repo hints

### DIFF
--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -33,7 +33,12 @@ class Developer(Toolkit):
 
     def system(self) -> str:
         """Retrieve system configuration details for developer"""
-        return Message.load("prompts/developer.jinja").text
+        hints_path = Path('.goosehints')
+        system_prompt = Message.load("prompts/developer.jinja").text
+        if hints_path.is_file():
+            goosehints = hints_path.read_text()
+            system_prompt = f"{system_prompt}\n\nHints:\n{goosehints}"
+        return system_prompt
 
     @tool
     def update_plan(self, tasks: List[dict]) -> List[dict]:

--- a/tests/toolkit/test_developer.py
+++ b/tests/toolkit/test_developer.py
@@ -1,17 +1,5 @@
 from pathlib import Path
 
-def test_system_without_hints(temp_dir, developer_toolkit):
-    (temp_dir / 'prompts').mkdir(parents=True, exist_ok=True)
-    developer_toolkit.workspace = temp_dir
-    assert developer_toolkit.system()
-
-def test_system_with_hints(temp_dir, developer_toolkit):
-    hints_content = "Use Python 3.8"
-    (temp_dir / 'prompts').mkdir(parents=True, exist_ok=True)
-    with (temp_dir / '.goosehints').open('w') as f:
-        f.write(hints_content)
-    developer_toolkit.workspace = temp_dir
-    assert developer_toolkit.system()
 
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, Mock
@@ -80,3 +68,5 @@ def test_write_file(temp_dir, developer_toolkit):
     content = "Hello World"
     developer_toolkit.write_file(test_file.as_posix(), content)
     assert test_file.read_text() == content
+
+

--- a/tests/toolkit/test_developer.py
+++ b/tests/toolkit/test_developer.py
@@ -1,4 +1,18 @@
 from pathlib import Path
+
+def test_system_without_hints(temp_dir, developer_toolkit):
+    (temp_dir / 'prompts').mkdir(parents=True, exist_ok=True)
+    developer_toolkit.workspace = temp_dir
+    assert developer_toolkit.system()
+
+def test_system_with_hints(temp_dir, developer_toolkit):
+    hints_content = "Use Python 3.8"
+    (temp_dir / 'prompts').mkdir(parents=True, exist_ok=True)
+    with (temp_dir / '.goosehints').open('w') as f:
+        f.write(hints_content)
+    developer_toolkit.workspace = temp_dir
+    assert developer_toolkit.system()
+
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, Mock
 


### PR DESCRIPTION
After trying a few approaches, this simple one still seems potentially relevant (you can put specific instructions for goose in a repo). 