### PR TITLE
fix: resuming sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "goose-ai"
 description = "a programming agent that runs on your machine"
-version = "0.8.4"
+version = "0.8.5"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -2,7 +2,7 @@ import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from exchange import Message, ToolResult, ToolUse
+from exchange import Message, ToolResult, ToolUse, Text
 from prompt_toolkit.shortcuts import confirm
 from rich import print
 from rich.console import RenderableType
@@ -91,8 +91,23 @@ class Session:
 
         if name is not None and self.session_file_path.exists():
             messages = self.load_session()
+            resume_message = Message.assistant("I see we were interrupted. How can I help you?")
+
             if messages and messages[-1].role == "user":
+                if type(messages[-1].content[-1]) is Text:
+                    # remove the last user message
+                    messages.pop()
+                elif type(messages[-1].content[-1]) is ToolResult:
+                    # if we remove this message, we would need to remove
+                    # the previous assistant message as well. instead of doing
+                    # that, we just add a new assistant message to prompt the user
+                    messages.append(resume_message)
+            if messages and type(messages[-1].content[-1]) is ToolUse:
+                # remove the last request for a tool to be used
                 messages.pop()
+
+                # add a new assistant text message to prompt the user
+                messages.append()
             self.exchange.messages.extend(messages)
 
         if len(self.exchange.messages) == 0 and plan:

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -24,6 +24,8 @@ from goose.profile import Profile
 from goose.utils import droid, load_plugins
 from goose.utils.session_file import read_from_file, write_to_file
 
+RESUME_MESSAGE = "I see we were interrupted. How can I help you?"
+
 
 def load_provider() -> str:
     # We try to infer a provider, by going in order of what will auth
@@ -91,7 +93,6 @@ class Session:
 
         if name is not None and self.session_file_path.exists():
             messages = self.load_session()
-            resume_message = Message.assistant("I see we were interrupted. How can I help you?")
 
             if messages and messages[-1].role == "user":
                 if type(messages[-1].content[-1]) is Text:
@@ -101,13 +102,13 @@ class Session:
                     # if we remove this message, we would need to remove
                     # the previous assistant message as well. instead of doing
                     # that, we just add a new assistant message to prompt the user
-                    messages.append(resume_message)
+                    messages.append(Message.assistant(RESUME_MESSAGE))
             if messages and type(messages[-1].content[-1]) is ToolUse:
                 # remove the last request for a tool to be used
                 messages.pop()
 
                 # add a new assistant text message to prompt the user
-                messages.append()
+                messages.append(Message.assistant(RESUME_MESSAGE))
             self.exchange.messages.extend(messages)
 
         if len(self.exchange.messages) == 0 and plan:


### PR DESCRIPTION
Before this PR, when a session was resumed there were a few edge cases where we would fail to resume correctly. This PR fixes all of them to ensure we always can resume the session safely, while minimizing the context lost.