### PR TITLE
feat: show available toolkits

### DIFF
--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional
@@ -12,9 +11,11 @@ from goose.cli.session import Session
 from goose.utils import load_plugins
 from goose.utils.session_file import list_sorted_session_files
 
+
 @click.group()
 def goose_cli() -> None:
     pass
+
 
 @goose_cli.command()
 def version() -> None:
@@ -45,6 +46,19 @@ def version() -> None:
 def session() -> None:
     """Start or manage sessions"""
     pass
+
+
+@goose_cli.group()
+def toolkit() -> None:
+    """Manage toolkits"""
+    pass
+
+
+@toolkit.command(name="list")
+def list_toolkits() -> None:
+    print("[green]Available toolkits:[/green]")
+    for toolkit_name, toolkit in load_plugins("goose.toolkit").items():
+        print(f" - [bold]{toolkit_name}[/bold]: {toolkit.__doc__.split('\n')[0]}")
 
 
 @session.command(name="start")
@@ -100,13 +114,16 @@ def session_clear(keep: int) -> None:
 def get_session_files() -> Dict[str, Path]:
     return list_sorted_session_files(SESSIONS_PATH)
 
+
 @click.group(
-        invoke_without_command=True,
-        name="goose",
-        help="AI-powered tool to assist in solving programming and operational tasks",)
+    invoke_without_command=True,
+    name="goose",
+    help="AI-powered tool to assist in solving programming and operational tasks",
+)
 @click.pass_context
 def cli(_: click.Context, **kwargs: Dict) -> None:
     pass
+
 
 all_cli_group_options = load_plugins("goose.cli.group_option")
 for option in all_cli_group_options.values():

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -58,7 +58,8 @@ def toolkit() -> None:
 def list_toolkits() -> None:
     print("[green]Available toolkits:[/green]")
     for toolkit_name, toolkit in load_plugins("goose.toolkit").items():
-        print(f" - [bold]{toolkit_name}[/bold]: {toolkit.__doc__.split('\n')[0]}")
+        first_line_of_doc = toolkit.__doc__.split("\n")[0]
+        print(f" - [bold]{toolkit_name}[/bold]: {first_line_of_doc}")
 
 
 @session.command(name="start")

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -25,7 +25,7 @@ def keep_unsafe_command_prompt(command: str) -> PromptType:
 
 
 class Developer(Toolkit):
-    """The developer toolkit provides a set of general purpose development capabilities
+    """Provides a set of general purpose development capabilities
 
     The tools include plan management, a general purpose shell execution tool, and file operations.
     We also include some default shell strategies in the prompt, such as using ripgrep

--- a/src/goose/toolkit/lint.py
+++ b/src/goose/toolkit/lint.py
@@ -1,0 +1,12 @@
+from goose.utils import load_plugins
+
+
+def lint_toolkits() -> None:
+    for toolkit_name, toolkit in load_plugins("goose.toolkit").items():
+        assert toolkit.__doc__ is not None, f"`{toolkit_name}` toolkit must have a docstring"
+        first_line_of_docstring = toolkit.__doc__.split("\n")[0]
+        assert len(first_line_of_docstring.split(" ")) > 5, f"`{toolkit_name}` toolkit docstring is too short"
+        assert len(first_line_of_docstring.split(" ")) < 12, f"`{toolkit_name}` toolkit docstring is too long"
+        assert first_line_of_docstring[
+            0
+        ].isupper(), f"`{toolkit_name}` toolkit docstring must start with a capital letter"

--- a/src/goose/toolkit/repo_context/repo_context.py
+++ b/src/goose/toolkit/repo_context/repo_context.py
@@ -14,6 +14,8 @@ from goose.utils.ask import clear_exchange, replace_prompt
 
 
 class RepoContext(Toolkit):
+    """Provides context about the current repository"""
+
     def __init__(self, notifier: Notifier, requires: Requirements) -> None:
         super().__init__(notifier=notifier, requires=requires)
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -85,31 +85,37 @@ def test_session_clear_command(mock_session_files_path, create_session_file):
 def test_combined_group_option():
     with patch("goose.utils.load_plugins") as mock_load_plugin:
         group_option_name = "--describe-commands"
+
         def option_callback(ctx, *_):
             click.echo("Option callback")
             ctx.exit()
+
         mock_group_options = {
-            'option1': lambda: click.option(
+            "option1": lambda: click.option(
                 group_option_name,
                 is_flag=True,
                 callback=option_callback,
             ),
         }
+
         def side_effect_func(param):
             if param == "goose.cli.group_option":
                 return mock_group_options
             elif param == "goose.cli.group":
-                return {  }
+                return {}
+
         mock_load_plugin.side_effect = side_effect_func
 
         # reload cli after mocking
-        importlib.reload(importlib.import_module('goose.cli.main'))
+        importlib.reload(importlib.import_module("goose.cli.main"))
         import goose.cli.main
+
         cli = goose.cli.main.cli
 
         runner = CliRunner()
         result = runner.invoke(cli, [group_option_name])
         assert result.exit_code == 0
+
 
 def test_combined_group_commands(mock_session):
     mock_session_class, mock_session_instance = mock_session
@@ -117,4 +123,3 @@ def test_combined_group_commands(mock_session):
     runner.invoke(cli, ["session", "resume", "session1", "--profile", "default"])
     mock_session_class.assert_called_once_with(name="session1", profile="default")
     mock_session_instance.run.assert_called_once()
-

--- a/tests/test_linting.py
+++ b/tests/test_linting.py
@@ -1,0 +1,5 @@
+from goose.toolkit.lint import lint_toolkits
+
+
+def test_lint_toolkits():
+    lint_toolkits()


### PR DESCRIPTION
Folks did not have a reliable way of discovering toolkits, adding this so they can view all available ones.

Output of running `goose toolkit list`
```
Available toolkits:
 - developer: Provides a set of general purpose development capabilities
 - github: Provides an additional prompt on how to interact with Github
 - repo_context: Provides context about the current repository
 - screen: Provides an instructions on when and how to work with screenshots
```