### PR TITLE
add a jira toolkit

### DIFF
--- a/.goosehints
+++ b/.goosehints
@@ -1,0 +1,2 @@
+This is a python CLI app that uses UV. Read CONTRIBUTING.md for information on how to build and test it as needed.
+Some key concepts are that it is run as a command line interface, dependes on the "ai-exchange" package, and has the concept of toolkits which are ways that its behavior can be extended. Look in src/goose and tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ goose-ai = "goose.module_name"
 [project.entry-points."goose.toolkit"]
 developer = "goose.toolkit.developer:Developer"
 github = "goose.toolkit.github:Github"
+jira = "goose.toolkit.jira:Jira"
 screen = "goose.toolkit.screen:Screen"
 repo_context = "goose.toolkit.repo_context.repo_context:RepoContext"
 

--- a/src/goose/toolkit/jira.py
+++ b/src/goose/toolkit/jira.py
@@ -1,0 +1,27 @@
+from exchange import Message  # type: ignore
+from goose.toolkit.base import tool  # type: ignore
+import re
+
+from goose.toolkit.base import Toolkit
+
+
+class Jira(Toolkit):
+    """Provides an additional prompt on how to interact with Jira"""
+
+    def system(self) -> str:
+        """Retrieve detailed configuration and procedural guidelines for Jira operations"""
+        return Message.load("prompts/jira.jinja").text
+
+    @tool
+    def is_jira_issue(self, issue_key: str) -> str:
+        """
+        Checks if a given string is a valid JIRA issue key.
+        Use this if it looks like the user is asking about a JIRA issue.
+
+        Args:
+            issue_key (str): The potential Jira issue key to be validated.
+
+        """        
+        pattern = r"[A-Z]+-\d+"
+        return bool(re.match(pattern, issue_key))
+

--- a/src/goose/toolkit/prompts/jira.jinja
+++ b/src/goose/toolkit/prompts/jira.jinja
@@ -1,0 +1,23 @@
+You can interact with jira issues via the `jira` command line generally.
+If it fails to auth, prompt the user to run `jira init` in a separate terminal and then try again.
+
+Typically when someone requests you to look at a ticket, they mean to view
+not just the top level comments and history, but also the comments nested within that ticket and status.
+
+Some usages are for looking up a JIRA backlog, or looking up a JIRA issue.
+Use the tool is_jira_issue if not sure that a string that looks like a jira issue is.
+
+Use `jira --help` if not sure of command line options.
+
+If the jira command line is not installed, you can install it as follows:
+
+{% if os == 'Darwin' %}
+On macOS, install with:
+```sh
+brew tap ankitpokhrel/jira-cli
+brew install jira-cli
+```
+{% else %}
+On other operating systems, refer to the instructions here: https://github.com/ankitpokhrel/jira-cli
+{% endif %}
+

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+from goose.toolkit.jira import Jira
+
+class TestJiraToolkit(unittest.TestCase):
+    
+    @patch('goose.toolkit.jira.Message.load')
+    def test_jira_system_prompt(self, mock_load):
+        mock_load.return_value.text = "This is a prompt for jira"
+        jira_toolkit = Jira(None)
+        prompt = jira_toolkit.system()
+        # Ensure Jinja template syntax isn't present in the loaded prompt
+        self.assertNotIn("{%", prompt)
+        self.assertNotIn("%}", prompt)
+        self.assertEqual(prompt, "This is a prompt for jira")
+
+    def test_is_jira_issue(self):
+        jira_toolkit = Jira(None)
+        valid_jira_issue = "PROJ-123"
+        invalid_jira_issue = "INVALID_ISSUE"
+        # Ensure the regex correctly identifies valid JIRA issues
+        self.assertTrue(jira_toolkit.is_jira_issue(valid_jira_issue))
+        self.assertFalse(jira_toolkit.is_jira_issue(invalid_jira_issue))
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
adding jira to profiles: 

```yaml
jira:
  provider: openai
  processor: gpt-4o
  accelerator: gpt-4o-mini
  moderator: truncate
  toolkits:
  - name: developer
    requires: {}
  - name: jira
    requires: {}      
  - name: github
    requires: {}   
```

and you can ask it about backlogs, issues, even to look for issues it can work on and more. 