### PR TITLE
fix: enhance shell() to know when it is interactive

### DIFF
--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -255,7 +255,7 @@ class Developer(Toolkit):
             stdout_thread.join()
             stderr_thread.join()
             return (
-                "Command requires interactive input.\n"
+                "Command requires interactive input. If unclear, prompt user for required input or ask to run outside of goose.\n"
                 f"Output:\n{output}\nError:\n{error}"
             )
 

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -266,8 +266,10 @@ class Developer(Toolkit):
                 # Call maybe_prompt with the last 2 to 10 recent lines
                 lines_to_check = recent_lines[-10:]
                 self.notifier.log(f"Still working\n{''.join(lines_to_check)}")
+                if not lines_to_check or len(recent_lines) == 0:
+                    lines_to_check = list(['busy...'])
                 response = ask_an_ai(
-                    input=("\n").join(recent_lines),
+                    input=("\n").join(lines_to_check),
                     prompt="This looks to see if the lines provided from running a command are potentially waiting"
                     + " for something, running a server or something that will not termiinate in a shell."
                     + " Return [Yes], if so [No] otherwise.",

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -206,11 +206,11 @@ class Developer(Toolkit):
                     input="\n".join([command] + output_lines),
                     prompt=(
                         "You will evaluate the output of shell commands to see if they may be stuck."
-                        " If the command appears to be awaiting user input, or otherwise running indefinitely (such as a web service)."  # noqa
-                        " Long running tasks are okay, only identify tasks that are awaiting input or will otherwise never terminate."  # noqa
-                        " return [Yes] if so [No] otherwise."
+                        " Look for commands that appear to be awaiting user input, or otherwise running indefinitely (such as a web service)."  # noqa
+                        " A command that will take a while, such as downloading resources is okay."  # noqa
+                        " return [Yes] if stuck, [No] otherwise."
                     ),
-                    exchange=self.exchange_view.accelerator,
+                    exchange=self.exchange_view.processor,
                     with_tools=False,
                 )
                 exit_criteria = "[yes]" in response.content[0].text.lower()

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -318,7 +318,7 @@ class Developer(Toolkit):
         else:
             result = f"Command failed with returncode {proc.returncode}"
 
-        # Return the combined result and outputs
+        # Return the combined result and outputs if we made it this far
         return "\n".join([result, output, error])
 
     @tool

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -267,7 +267,7 @@ class Developer(Toolkit):
                 lines_to_check = recent_lines[-10:]
                 self.notifier.log(f"Still working\n{''.join(lines_to_check)}")
                 if not lines_to_check or len(recent_lines) == 0:
-                    lines_to_check = list(['busy...'])
+                    lines_to_check = list(["busy..."])
                 response = ask_an_ai(
                     input=("\n").join(lines_to_check),
                     prompt="This looks to see if the lines provided from running a command are potentially waiting"

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -18,7 +18,6 @@ import re
 import time
 
 
-
 from goose.toolkit.base import Toolkit, tool
 from goose.toolkit.utils import get_language, render_template
 
@@ -140,7 +139,6 @@ class Developer(Toolkit):
         self.timestamps[path] = os.path.getmtime(path)
         return f"```{language}\n{content}\n```"
 
-
     @tool
     def shell(self, command: str) -> str:
         """
@@ -172,13 +170,13 @@ class Developer(Toolkit):
 
         # Define patterns that might indicate the process is waiting for input
         interaction_patterns = [
-            r'Do you want to',             # Common prompt phrase
-            r'Enter password',             # Password prompt
-            r'Are you sure',               # Confirmation prompt
-            r'\(y/N\)',                    # Yes/No prompt
-            r'Press any key to continue',  # Awaiting keypress
-            r'Waiting for input',          # General waiting message
-            r'\?\s'                        # Prompts starting with '? '
+            r"Do you want to",  # Common prompt phrase
+            r"Enter password",  # Password prompt
+            r"Are you sure",  # Confirmation prompt
+            r"\(y/N\)",  # Yes/No prompt
+            r"Press any key to continue",  # Awaiting keypress
+            r"Waiting for input",  # General waiting message
+            r"\?\s",  # Prompts starting with '? '
         ]
         compiled_patterns = [re.compile(pattern, re.IGNORECASE) for pattern in interaction_patterns]
 
@@ -189,7 +187,7 @@ class Developer(Toolkit):
             stdin=subprocess.DEVNULL,  # Close stdin to prevent the process from waiting for input
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True
+            text=True,
         )
 
         # Queues to store the output
@@ -199,12 +197,12 @@ class Developer(Toolkit):
         # Function to read stdout and stderr without blocking
         def reader_thread(pipe: any, output_queue: any) -> None:
             try:
-                for line in iter(pipe.readline, ''):
+                for line in iter(pipe.readline, ""):
                     output_queue.put(line)
                     # Check for prompt patterns
                     for pattern in compiled_patterns:
                         if pattern.search(line):
-                            output_queue.put('INTERACTION_DETECTED')
+                            output_queue.put("INTERACTION_DETECTED")
             finally:
                 pipe.close()
 
@@ -215,8 +213,8 @@ class Developer(Toolkit):
         stderr_thread.start()
 
         # Collect output
-        output = ''
-        error = ''
+        output = ""
+        error = ""
 
         # Initialize timer and recent lines list
         last_line_time = time.time()
@@ -232,7 +230,7 @@ class Developer(Toolkit):
             try:
                 while True:
                     line = stdout_queue.get_nowait()
-                    if line == 'INTERACTION_DETECTED':
+                    if line == "INTERACTION_DETECTED":
                         return (
                             "Command requires interactive input. If unclear, prompt user for required input "
                             f"or ask to run outside of goose.\nOutput:\n{output}\nError:\n{error}"
@@ -250,7 +248,7 @@ class Developer(Toolkit):
             try:
                 while True:
                     line = stderr_queue.get_nowait()
-                    if line == 'INTERACTION_DETECTED':
+                    if line == "INTERACTION_DETECTED":
                         return (
                             "Command requires interactive input. If unclear, prompt user for required input "
                             f"or ask to run outside of goose.\nOutput:\n{output}\nError:\n{error}"
@@ -263,25 +261,26 @@ class Developer(Toolkit):
             except queue.Empty:
                 pass
 
-
             # Check if no new lines have been received for 10 seconds
             if time.time() - last_line_time > 10:
                 # Call maybe_prompt with the last 2 to 10 recent lines
                 lines_to_check = recent_lines[-10:]
                 self.notifier.log(f"Still working\n{''.join(lines_to_check)}")
-                response = ask_an_ai(input=('\n').join(recent_lines),
-                        prompt='This looks to see if the lines provided from running a command are potentially waiting'
-                            +' for something, running a server or something that will not termiinate in a shell.'
-                            +' Return [Yes], if so [No] otherwise.',
-                        exchange=self.exchange_view.accelerator)
-                if response.content[0].text == '[Yes]':
-                        answer = (
-                            f"The command {command} looks to be a long running task. "
-                            f"Do not run it in goose but tell user to run it outside, "
-                            f"unless the user explicitly tells you to run it (and then, "
-                            f"remind them they will need to cancel it as long running)."
-                        )
-                        return answer
+                response = ask_an_ai(
+                    input=("\n").join(recent_lines),
+                    prompt="This looks to see if the lines provided from running a command are potentially waiting"
+                    + " for something, running a server or something that will not termiinate in a shell."
+                    + " Return [Yes], if so [No] otherwise.",
+                    exchange=self.exchange_view.accelerator,
+                )
+                if response.content[0].text == "[Yes]":
+                    answer = (
+                        f"The command {command} looks to be a long running task. "
+                        f"Do not run it in goose but tell user to run it outside, "
+                        f"unless the user explicitly tells you to run it (and then, "
+                        f"remind them they will need to cancel it as long running)."
+                    )
+                    return answer
                 else:
                     self.notifier.log(f"Will continue to run {command}")
 
@@ -290,7 +289,6 @@ class Developer(Toolkit):
 
             # Brief sleep to prevent high CPU usage
             threading.Event().wait(0.1)
-
 
         # Wait for process to complete
         proc.wait()
@@ -326,7 +324,6 @@ class Developer(Toolkit):
 
         # Return the combined result and outputs
         return "\n".join([result, output, error])
-
 
     @tool
     def write_file(self, path: str, content: str) -> str:

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -268,7 +268,7 @@ class Developer(Toolkit):
             if time.time() - last_line_time > 10:
                 # Call maybe_prompt with the last 2 to 10 recent lines
                 lines_to_check = recent_lines[-10:]
-                self.notifier.log(f"Still working:\n{''.join(lines_to_check)}")
+                self.notifier.log(f"Still working\n{''.join(lines_to_check)}")
                 response = ask_an_ai(input=('\n').join(recent_lines),
                         prompt='This looks to see if the lines provided from running a command are potentially waiting'
                             +' for something, running a server or something that will not termiinate in a shell.'

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -21,9 +21,7 @@ from rich.text import Text
 def keep_unsafe_command_prompt(command: str) -> bool:
     command_text = Text(command, style="bold red")
     message = (
-        Text("\nWe flagged the command: ")
-        + command_text
-        + Text(" as potentially unsafe, do you want to proceed?")
+        Text("\nWe flagged the command: ") + command_text + Text(" as potentially unsafe, do you want to proceed?")
     )
     return Confirm.ask(message, default=True)
 
@@ -104,13 +102,9 @@ class Developer(Toolkit):
         content = _path.read_text()
 
         if content.count(before) > 1:
-            raise ValueError(
-                "The before content is present multiple times in the file, be more specific."
-            )
+            raise ValueError("The before content is present multiple times in the file, be more specific.")
         if content.count(before) < 1:
-            raise ValueError(
-                "The before content was not found in file, be careful that you recreate it exactly."
-            )
+            raise ValueError("The before content was not found in file, be careful that you recreate it exactly.")
 
         content = content.replace(before, after)
         _path.write_text(content)
@@ -155,9 +149,7 @@ class Developer(Toolkit):
                 if you need to run more than one at a time
         """
         # Log the command being executed in a visually structured format (Markdown).
-        self.notifier.log(
-            Panel.fit(Markdown(f"```bash\n{command}\n```"), title="shell")
-        )
+        self.notifier.log(Panel.fit(Markdown(f"```bash\n{command}\n```"), title="shell"))
 
         if is_dangerous_command(command):
             # Stop the notifications so we can prompt
@@ -180,9 +172,7 @@ class Developer(Toolkit):
             r"Waiting for input",  # General waiting message
             r"\?\s",  # Prompts starting with '? '
         ]
-        compiled_patterns = [
-            re.compile(pattern, re.IGNORECASE) for pattern in interaction_patterns
-        ]
+        compiled_patterns = [re.compile(pattern, re.IGNORECASE) for pattern in interaction_patterns]
 
         proc = subprocess.Popen(
             command,
@@ -216,7 +206,8 @@ class Developer(Toolkit):
                     input="\n".join([command] + output_lines),
                     prompt=(
                         "You will evaluate the output of shell commands to see if they may be stuck."
-                        " If the command appears to be awaiting user input, or otherwise running indefinitely (such as a web service)"
+                        " If the command appears to be awaiting user input, or otherwise running indefinitely (such as a web service)."  # noqa
+                        " Long running tasks are okay, only identify tasks that are awaiting input or will otherwise never terminate."  # noqa
                         " return [Yes] if so [No] otherwise."
                     ),
                     exchange=self.exchange_view.accelerator,
@@ -231,7 +222,7 @@ class Developer(Toolkit):
                 raise ValueError(
                     f"The command `{command}` looks like it will run indefinitely or is otherwise stuck."
                     f"You may be able to specify inputs if it applies to this command."
-                    f"Otherwise to enable continued iteration, you'll need to ask the user to run this command in another terminal."
+                    f"Otherwise to enable continued iteration, you'll need to ask the user to run this command in another terminal."  # noqa
                 )
 
         # read any remaining lines

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -302,8 +302,6 @@ class Developer(Toolkit):
             while True:
                 line = stdout_queue.get_nowait()
                 output += line
-                recent_lines.append(line)
-                recent_lines = recent_lines[-10:]
         except queue.Empty:
             pass
 
@@ -311,8 +309,6 @@ class Developer(Toolkit):
             while True:
                 line = stderr_queue.get_nowait()
                 error += line
-                recent_lines.append(line)
-                recent_lines = recent_lines[-10:]
         except queue.Empty:
             pass
 

--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -228,6 +228,7 @@ class Developer(Toolkit):
             # Process output from stdout
             try:
                 line = stdout_queue.get_nowait()
+                #print('out line', line)
                 if line == 'PROMPT_DETECTED':
                     is_waiting_for_input = True
                     break
@@ -239,6 +240,7 @@ class Developer(Toolkit):
             # Process output from stderr
             try:
                 line = stderr_queue.get_nowait()
+                #print('err line', line)
                 if line == 'PROMPT_DETECTED':
                     is_waiting_for_input = True
                     break

--- a/src/goose/utils/ask.py
+++ b/src/goose/utils/ask.py
@@ -70,9 +70,7 @@ def clear_exchange(exchange: Exchange, clear_tools: bool = False) -> Exchange:
 
     """
     if clear_tools:
-        new_exchange = exchange.replace(
-            messages=[], checkpoint_data=CheckpointData(), tools=()
-        )
+        new_exchange = exchange.replace(messages=[], checkpoint_data=CheckpointData(), tools=())
     else:
         new_exchange = exchange.replace(messages=[], checkpoint_data=CheckpointData())
     return new_exchange

--- a/src/goose/utils/ask.py
+++ b/src/goose/utils/ask.py
@@ -1,7 +1,13 @@
 from exchange import Exchange, Message, CheckpointData
 
 
-def ask_an_ai(input: str, exchange: Exchange, prompt: str = "", no_history: bool = True) -> Message:
+def ask_an_ai(
+    input: str,
+    exchange: Exchange,
+    prompt: str = "",
+    no_history: bool = True,
+    with_tools: bool = True,
+) -> Message:
     """Sends a separate message to an LLM using a separate Exchange than the one underlying the Goose session.
 
     Can be used to summarize a file, or submit any other request that you'd like to an AI. The Exchange can have a
@@ -36,6 +42,9 @@ def ask_an_ai(input: str, exchange: Exchange, prompt: str = "", no_history: bool
     if no_history:
         exchange = clear_exchange(exchange)
 
+    if not with_tools:
+        exchange = exchange.replace(tools=())
+
     if prompt:
         exchange = replace_prompt(exchange, prompt)
 
@@ -61,7 +70,9 @@ def clear_exchange(exchange: Exchange, clear_tools: bool = False) -> Exchange:
 
     """
     if clear_tools:
-        new_exchange = exchange.replace(messages=[], checkpoint_data=CheckpointData(), tools=())
+        new_exchange = exchange.replace(
+            messages=[], checkpoint_data=CheckpointData(), tools=()
+        )
     else:
         new_exchange = exchange.replace(messages=[], checkpoint_data=CheckpointData())
     return new_exchange


### PR DESCRIPTION
This will either return to user and ask them to run it themselves, or ask for more information, or work out how to run it with the information it has. Uses patterns and the accelerator model to supervise command output

fixes: https://github.com/square/goose/issues/49

How this works: 

* Watches stdout and stderr
* looks for patterns which may indicate it is blocking for user response
* If there is will return to the user or ask for more input (no blocking)
* If the process doesn't return any output for a time, it examines the log with the `acclerator` model to see if it may be a long running process and confirm with the user. 

For example, both of these are interactive commands now handled: 

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/46ac82a9-cc1a-4707-b4f3-c4ee350cd15c">

<img width="994" alt="image" src="https://github.com/user-attachments/assets/a22e2a2b-f2e2-450f-918b-ba4aba3cce27">

The former one uses the accelerator model to detect if it is long running or not. Former uses a pattern to detect. 
Can also log stdout etc now (if we wanted a mode for that) - but you can just ask goose to show you
