### PR TITLE
docs: fix broken link

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,4 +163,4 @@ def example_history(self):
     ...
 ```
 
-[exchange]: https://github.com/squareup/exchange
+[exchange]: https://github.com/square/exchange


### PR DESCRIPTION
exchange is now in square, not squareup