### PR TITLE
feat: add version options

### DIFF
--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -17,7 +17,7 @@ def goose_cli() -> None:
     pass
 
 
-@goose_cli.command("version")
+@goose_cli.command(name="version")
 def get_version() -> None:
     """Lists the version of goose and any plugins"""
     from importlib.metadata import entry_points, version

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import click
 from rich import print
@@ -112,7 +112,7 @@ def session_clear(keep: int) -> None:
             session_file.unlink()
 
 
-def get_session_files() -> Dict[str, Path]:
+def get_session_files() -> dict[str, Path]:
     return list_sorted_session_files(SESSIONS_PATH)
 
 

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -17,8 +17,8 @@ def goose_cli() -> None:
     pass
 
 
-@goose_cli.command()
-def version() -> None:
+@goose_cli.command("version")
+def get_version() -> None:
     """Lists the version of goose and any plugins"""
     from importlib.metadata import entry_points, version
 
@@ -121,9 +121,14 @@ def get_session_files() -> Dict[str, Path]:
     name="goose",
     help="AI-powered tool to assist in solving programming and operational tasks",
 )
+@click.option("-V", "--version", is_flag=True, help="List the version of goose and any plugins")
 @click.pass_context
-def cli(_: click.Context, **kwargs: Dict) -> None:
-    pass
+def cli(ctx: click.Context, version: bool, **kwargs: dict) -> None:
+    if version:
+        ctx.invoke(get_version)
+        ctx.exit()
+    elif ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 all_cli_group_options = load_plugins("goose.cli.group_option")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -144,3 +144,12 @@ def test_version_subcommand():
     result = runner.invoke(cli, ["version"])
     assert result.exit_code == 0
     assert "version" in result.output.lower()
+
+
+def test_goose_no_args_print_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "Options:" in result.output
+    assert "Commands:" in result.output

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -123,3 +123,24 @@ def test_combined_group_commands(mock_session):
     runner.invoke(cli, ["session", "resume", "session1", "--profile", "default"])
     mock_session_class.assert_called_once_with(name="session1", profile="default")
     mock_session_instance.run.assert_called_once()
+
+
+def test_version_long_option():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert "version" in result.output.lower()
+
+
+def test_version_short_option():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["-V"])
+    assert result.exit_code == 0
+    assert "version" in result.output.lower()
+
+
+def test_version_subcommand():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["version"])
+    assert result.exit_code == 0
+    assert "version" in result.output.lower()


### PR DESCRIPTION
  - replace legacy `Dict` with buitin `dict` for python >= 3.9+ / PEP585
  - add `-V` / `--version` flags to match other cli tools
    * chose `-V` since many applications use `-v` as `--verbose`, which may be useful if we add debug logging

## Test + Example outputs
```fish
$ uv run goose version
Goose-ai: 0.9.0
Plugins:
  Module: ai-exchange, Version: 0.9.0

$ uv run goose --version
Goose-ai: 0.9.0
Plugins:
  Module: ai-exchange, Version: 0.9.0

$ uv run goose -V
Goose-ai: 0.9.0
Plugins:
  Module: ai-exchange, Version: 0.9.0
```

```fish
$ uv --version
uv 0.3.3 (deea6025a 2024-08-23)

$ uv -V
uv 0.3.3 (deea6025a 2024-08-23)

$ uv version
uv 0.3.3 (deea6025a 2024-08-23)
```

```fish
$ git --version
git version 2.45.2

$ git -v
git version 2.45.2

$ git version
git version 2.45.2
```

