### PR TITLE
fix: remove overly general match for long running commands

### DIFF
--- a/src/goose/toolkit/developer.py
+++ b/src/goose/toolkit/developer.py
@@ -170,7 +170,6 @@ class Developer(Toolkit):
             r"\(y/N\)",  # Yes/No prompt
             r"Press any key to continue",  # Awaiting keypress
             r"Waiting for input",  # General waiting message
-            r"\?\s",  # Prompts starting with '? '
         ]
         compiled_patterns = [re.compile(pattern, re.IGNORECASE) for pattern in interaction_patterns]
 


### PR DESCRIPTION
this was picking up too much in output